### PR TITLE
feat: 重複ファイル名リネーム機能 (#9)

### DIFF
--- a/photo_mover/mover.py
+++ b/photo_mover/mover.py
@@ -11,6 +11,21 @@ logger = logging.getLogger(__name__)
 DEFAULT_EXTENSIONS = {"jpg", "jpeg", "png", "heic", "mp4", "mov", "avi", "gif"}
 
 
+def _resolve_target(target: Path) -> Path:
+    """Return a non-colliding path by appending _1, _2, ... if target exists."""
+    if not target.exists():
+        return target
+    stem = target.stem
+    suffix = target.suffix
+    parent = target.parent
+    n = 1
+    while True:
+        candidate = parent / f"{stem}_{n}{suffix}"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
 def is_media(path: Path, extensions: Iterable[str]) -> bool:
     return path.is_file() and path.suffix.lstrip(".").lower() in extensions
 
@@ -49,7 +64,7 @@ def move_media(
         try:
             if is_media(p, extensions):
                 rel = p.relative_to(src)
-                target = dst.joinpath(rel.name)
+                target = _resolve_target(dst.joinpath(rel.name))
                 if dry_run:
                     logger.info("DRY RUN: move %s -> %s", p, target)
                     moved.append(target)

--- a/tests/test_mover.py
+++ b/tests/test_mover.py
@@ -60,3 +60,84 @@ def test_cli_dry_run(tmp_path):
 
     assert not (dst / "photo.jpg").exists()
     assert (src / "photo.jpg").exists()
+
+
+def test_duplicate_rename_basic(tmp_path):
+    """dst に同名ファイルが既存 → photo_1.jpg にリネームされる"""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    touch(src / "photo.jpg")
+    touch(dst / "photo.jpg")
+
+    moved = move_media(src, dst, recursive=False, dry_run=False)
+
+    assert len(moved) == 1
+    assert moved[0] == dst / "photo_1.jpg"
+    assert (dst / "photo_1.jpg").exists()
+    assert (dst / "photo.jpg").exists()
+
+
+def test_duplicate_rename_multiple(tmp_path):
+    """dst に photo.jpg と photo_1.jpg が既存 → photo_2.jpg になる"""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    touch(src / "photo.jpg")
+    touch(dst / "photo.jpg")
+    touch(dst / "photo_1.jpg")
+
+    moved = move_media(src, dst, recursive=False, dry_run=False)
+
+    assert len(moved) == 1
+    assert moved[0] == dst / "photo_2.jpg"
+    assert (dst / "photo_2.jpg").exists()
+
+
+def test_duplicate_rename_dry_run(tmp_path):
+    """dry-run でもリネーム後のパスを返す"""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    touch(src / "photo.jpg")
+    touch(dst / "photo.jpg")
+
+    moved = move_media(src, dst, recursive=False, dry_run=True)
+
+    assert len(moved) == 1
+    assert moved[0] == dst / "photo_1.jpg"
+
+
+def test_duplicate_no_overwrite(tmp_path):
+    """既存ファイルの内容が上書きされない"""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "photo.jpg").write_bytes(b"new_file")
+    (dst / "photo.jpg").write_bytes(b"original")
+
+    move_media(src, dst, recursive=False, dry_run=False)
+
+    assert (dst / "photo.jpg").read_bytes() == b"original"
+    assert (dst / "photo_1.jpg").read_bytes() == b"new_file"
+
+
+def test_duplicate_rename_returns_renamed_path(tmp_path):
+    """戻り値が正しいリネーム後パスで、そのファイルが存在する"""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    touch(src / "photo.jpg")
+    touch(dst / "photo.jpg")
+    touch(dst / "photo_1.jpg")
+
+    moved = move_media(src, dst, recursive=False, dry_run=False)
+
+    assert len(moved) == 1
+    assert moved[0] == dst / "photo_2.jpg"
+    assert (dst / "photo_2.jpg").exists()


### PR DESCRIPTION
## Summary

- 移動先に同名ファイルが存在する場合、`photo_1.jpg` のように連番サフィックスを付与して衝突を回避する機能を追加する (#9)
- TDD Red フェーズとして、失敗するテスト5件を追加済み
  - `test_duplicate_rename_basic` — 基本的な重複リネーム
  - `test_duplicate_rename_multiple` — 連番スキップ (`_1` が存在 → `_2`)
  - `test_duplicate_rename_dry_run` — dry-run でもリネーム後パスを返す
  - `test_duplicate_no_overwrite` — 既存ファイル上書き禁止
  - `test_duplicate_rename_returns_renamed_path` — 戻り値が正しいパス

## Test plan

- [x] Green フェーズ: `mover.py` にリネームロジックを実装し、5件のテストを PASS させる
- [x] 既存テスト4件が引き続き PASS することを確認
- [x] `uv run black --check` で lint が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)